### PR TITLE
fix: remove duplicated pending WHMCS sync check

### DIFF
--- a/pkg/billing/invoices.go
+++ b/pkg/billing/invoices.go
@@ -1422,15 +1422,6 @@ func (s *BillingServiceServer) payWithBalanceWhmcsInvoice(ctx context.Context, i
 		return nil, status.Error(codes.FailedPrecondition, "Invoice is being synchronized. Please try again in a few seconds.")
 	}
 
-	pending, err := s.hasPendingWhmcsSyncInvoice(ctx, requester)
-	if err != nil {
-		log.Error("Failed to check pending WHMCS sync invoices", zap.Error(err))
-		return nil, status.Error(codes.Internal, "Internal error. Couldn't verify invoice state")
-	}
-	if pending {
-		return nil, status.Error(codes.FailedPrecondition, "Invoice is being synchronized. Please try again in a few seconds.")
-	}
-
 	acc, err := s.accounts.Get(ctx, requester)
 	if err != nil {
 		log.Warn("Failed to get account", zap.Error(err))


### PR DESCRIPTION
## Summary
- Merge of `#2318` into `dev` duplicated the `hasPendingWhmcsSyncInvoice` block in `payWithBalanceWhmcsInvoice`.
- Second `pending, err :=` failed CI with `no new variables on left side of :=`.

## Test plan
- [x] `go build -ldflags="-s -w" -buildvcs=false ./cmd/billing`

Made with [Cursor](https://cursor.com)