### PR TITLE
fix(instances): pass instance uuid in addon START ansible hooks

### DIFF
--- a/pkg/graph/instances.go
+++ b/pkg/graph/instances.go
@@ -846,7 +846,7 @@ func (ctrl *instancesController) Update(ctx context.Context, _ string, inst, old
 			}
 			if addon.Action != nil && addon.Action.GetPlaybook() != "" {
 				c := pb.Context{
-					Instance: inst.GetUuid(),
+					Instance: uuid,
 					Sp:       sp,
 					Event:    "START",
 					Addon:    &a,
@@ -1032,7 +1032,7 @@ func (ctrl *instancesController) UpdateWithPatch(ctx context.Context, _ string, 
 			}
 			if addon.Action != nil && addon.Action.GetPlaybook() != "" {
 				c := pb.Context{
-					Instance: inst.GetUuid(),
+					Instance: uuid,
 					Sp:       sp,
 					Event:    "START",
 					Addon:    &a,


### PR DESCRIPTION
After Update clears inst.Uuid for hashing, addon auto_start hooks used the empty value so playbooks never ran after payment.