### PR TITLE
Merge dev into master: Auto tickets + renew/drive handlers

### DIFF
--- a/pkg/eventbus/handlers.go
+++ b/pkg/eventbus/handlers.go
@@ -24,10 +24,10 @@ import (
 type EventHandler func(context.Context, *zap.Logger, *pb.Event, driver.Database) (*pb.Event, error)
 
 var (
-	overdueCCHost                string
-	overdueSigningKey            []byte
-	overdueDepartmentKey         string
-	overdueWhmcsSenderUUID       string
+	overdueCCHost          string
+	overdueSigningKey      []byte
+	overdueDepartmentKey   string
+	overdueWhmcsSenderUUID string
 )
 
 func SetupOverdueTicketHandler(ccHost string, signingKey []byte, departmentKey, whmcsSenderUUID string) {
@@ -94,7 +94,8 @@ LET rate = PRODUCT(
 		RETURN edge.rate
 )
 
-LET price = doc.billing_plan.products[doc.product] == null ? 0 : doc.billing_plan.products[doc.product].price
+	LET product_conf = doc.billing_plan.products[doc.product]
+	LET price = product_conf == null ? 0 : product_conf.price
 
 LET total = @inner_price == 0 ? price : @inner_price
 
@@ -104,7 +105,13 @@ RETURN {
 	service: srv.title, 
 	instance: doc.title, 
 	product: doc.product, 
+	period: product_conf == null ? 0 : product_conf.period,
 	next_payment_date: doc.data.next_payment_date,
+	due: doc.data.next_payment_date != null && doc.data.next_payment_date != 0
+		? doc.data.next_payment_date
+		: (doc.data.expiration != null && doc.data.expiration != 0
+			? doc.data.expiration
+			: doc.data.last_monitoring),
 	ips: doc.state.meta.networking.public,
 	price: total * rate
 }
@@ -118,6 +125,8 @@ type EventInfo struct {
 	Product         string  `json:"product,omitempty"`
 	Ips             []any   `json:"ips,omitempty"`
 	NextPaymentDate float64 `json:"next_payment_date,omitempty"`
+	Period          float64 `json:"period,omitempty"`
+	Due             float64 `json:"due,omitempty"`
 	Price           float64 `json:"price,omitempty"`
 }
 
@@ -223,39 +232,11 @@ type overdueCCDepartmentInfo struct {
 }
 
 func overdueCCDepartmentInfoFetch(ctx context.Context, token, departmentKey string) (*overdueCCDepartmentInfo, error) {
-	status, body, err := overdueCCPost(ctx, "/cc.UsersAPI/FetchDefaults", map[string]any{
-		"fetchTemplates": false,
-	}, token)
+	defaults, err := overdueCCFetchDefaults(ctx, token)
 	if err != nil {
 		return nil, err
 	}
-	if status >= 300 {
-		return nil, fmt.Errorf("fetch defaults: status %d: %s", status, string(body))
-	}
-
-	var defaults struct {
-		Departments []struct {
-			Key          string   `json:"key"`
-			Admins       []string `json:"admins"`
-			WhmcsID      string   `json:"whmcsId"`
-			WhmcsIDSnake string   `json:"whmcs_id"`
-		} `json:"departments"`
-	}
-	if err := json.Unmarshal(body, &defaults); err != nil {
-		return nil, fmt.Errorf("parse defaults: %w", err)
-	}
-
-	for _, dep := range defaults.Departments {
-		if dep.Key != departmentKey {
-			continue
-		}
-		wid := strings.TrimSpace(dep.WhmcsID)
-		if wid == "" {
-			wid = strings.TrimSpace(dep.WhmcsIDSnake)
-		}
-		return &overdueCCDepartmentInfo{Admins: dep.Admins, WhmcsID: wid}, nil
-	}
-	return nil, fmt.Errorf("department %q not found in CC config", departmentKey)
+	return defaults.departmentInfo(departmentKey)
 }
 
 func overdueAppendUniqueAdminUUID(admins []string, uuid string) []string {
@@ -385,30 +366,81 @@ func OverdueTicketHandler(ctx context.Context, log *zap.Logger, event *pb.Event,
 		return nil, fmt.Errorf("overdue ticket: sign token: %w", err)
 	}
 
+	defaults, err := overdueCCFetchDefaults(ctx, token)
+	if err != nil {
+		log.Warn("overdue ticket: failed to load chat settings, using env/hardcoded defaults", zap.Error(err))
+	}
+	ticketConf := overdueAutoTicketConf{
+		Enabled:    true,
+		Department: overdueDepartmentKey,
+		SenderUUID: overdueWhmcsSenderUUID,
+	}
+	if defaults != nil {
+		fromUI := defaults.autoTicketConf()
+		ticketConf.Enabled = fromUI.Enabled
+		if fromUI.Department != "" {
+			ticketConf.Department = fromUI.Department
+		}
+		if fromUI.SenderUUID != "" {
+			ticketConf.SenderUUID = fromUI.SenderUUID
+		}
+		ticketConf.Admins = fromUI.Admins
+		ticketConf.Responsible = fromUI.Responsible
+		ticketConf.Topic = fromUI.Topic
+		ticketConf.Message = fromUI.Message
+	}
+	if !ticketConf.Enabled {
+		log.Info("overdue ticket: disabled in chat settings, skipping")
+		event.Type = "noop"
+		return event, nil
+	}
+	if skipOverdueTicketUntilDelay(log, ticketConf, event.GetData(), info) {
+		event.Type = "noop"
+		return event, nil
+	}
+
+	topic, message := resolveOverdueTicketTexts(ticketConf, info)
 	createPayload := map[string]any{
 		"owner":  info.Account,
 		"users":  []string{info.Account},
-		"topic":  formatOverdueTicketTopic(info),
+		"topic":  topic,
 		"status": 0,
 	}
+	if ticketConf.Responsible != "" {
+		createPayload["responsible"] = ticketConf.Responsible
+	}
+
 	var deptWhmcsID string
-	if overdueDepartmentKey != "" {
-		createPayload["department"] = overdueDepartmentKey
-		deptInfo, err := overdueCCDepartmentInfoFetch(ctx, token, overdueDepartmentKey)
-		if err != nil {
-			log.Warn("overdue ticket: department config not loaded", zap.Error(err))
+	departmentKey := ticketConf.Department
+	senderUUID := ticketConf.SenderUUID
+	if departmentKey != "" {
+		createPayload["department"] = departmentKey
+		var (
+			deptInfo *overdueCCDepartmentInfo
+			deptErr  error
+		)
+		if defaults != nil {
+			deptInfo, deptErr = defaults.departmentInfo(departmentKey)
+		} else {
+			deptErr = fmt.Errorf("chat settings not loaded")
+		}
+		if deptErr != nil {
+			log.Warn("overdue ticket: department config not loaded", zap.Error(deptErr))
 		} else {
 			admins := deptInfo.Admins
 			deptWhmcsID = deptInfo.WhmcsID
-			if overdueWhmcsSenderUUID != "" {
-				admins = overdueAppendUniqueAdminUUID(admins, overdueWhmcsSenderUUID)
+			for _, extra := range ticketConf.Admins {
+				admins = overdueAppendUniqueAdminUUID(admins, extra)
+			}
+			if senderUUID != "" {
+				admins = overdueAppendUniqueAdminUUID(admins, senderUUID)
 			}
 			if len(admins) == 0 {
-				log.Warn("overdue ticket: department has no admins", zap.String("department", overdueDepartmentKey))
+				log.Warn("overdue ticket: department has no admins", zap.String("department", departmentKey))
 			} else {
 				createPayload["admins"] = admins
 				log.Debug("overdue ticket: assigned department admins",
-					zap.String("department", overdueDepartmentKey),
+					zap.String("department", departmentKey),
 					zap.Int("admins", len(admins)))
 			}
 			if deptWhmcsID != "" {
@@ -419,16 +451,24 @@ func OverdueTicketHandler(ctx context.Context, log *zap.Logger, event *pb.Event,
 				}
 			} else {
 				log.Warn("overdue ticket: CC department has no whmcsId; WHMCS OpenTicket may fail",
-					zap.String("department", overdueDepartmentKey))
+					zap.String("department", departmentKey))
 			}
 		}
-	} else if overdueWhmcsSenderUUID != "" {
-		createPayload["admins"] = []string{overdueWhmcsSenderUUID}
-		log.Warn("overdue ticket: OVERDUE_TICKET_WHMCS_SENDER_UUID set but OVERDUE_TICKET_DEPARTMENT empty; need department for WHMCS dept_id")
+	} else {
+		admins := slices.Clone(ticketConf.Admins)
+		if senderUUID != "" {
+			admins = overdueAppendUniqueAdminUUID(admins, senderUUID)
+		}
+		if len(admins) > 0 {
+			createPayload["admins"] = admins
+		}
+		if senderUUID != "" {
+			log.Warn("overdue ticket: sender is set but department is empty; need department for WHMCS dept_id")
+		}
 	}
 
-	if overdueDepartmentKey != "" && deptWhmcsID != "" && overdueWhmcsSenderUUID == "" {
-		log.Warn("overdue ticket: set OVERDUE_TICKET_WHMCS_SENDER_UUID (staff NoCloud UUID with whmcs_admin_id) so the first message opens WHMCS as admin")
+	if departmentKey != "" && deptWhmcsID != "" && senderUUID == "" {
+		log.Warn("overdue ticket: set sender UUID in Chat settings (staff NoCloud UUID with whmcs_admin_id) so the first message opens WHMCS as admin")
 	}
 
 	// ChatsAPI/Create sets chat owner from JWT (not from payload). Root → owner "0" (nocloud);
@@ -436,8 +476,8 @@ func OverdueTicketHandler(ctx context.Context, log *zap.Logger, event *pb.Event,
 	// Use the same staff JWT for Create+Send when configured so CC owner matches the opener.
 	createToken := token
 	sendToken := token
-	if overdueWhmcsSenderUUID != "" {
-		staffTok, err := overdueCCJWT(overdueWhmcsSenderUUID)
+	if senderUUID != "" {
+		staffTok, err := overdueCCJWT(senderUUID)
 		if err != nil {
 			return nil, fmt.Errorf("overdue ticket: sign staff token: %w", err)
 		}
@@ -457,6 +497,10 @@ func OverdueTicketHandler(ctx context.Context, log *zap.Logger, event *pb.Event,
 		return event, nil
 	}
 
+	if err := markOverdueTicketCreated(ctx, db, event.GetUuid()); err != nil {
+		log.Warn("overdue ticket: failed to persist created flag", zap.Error(err), zap.String("instance", event.GetUuid()))
+	}
+
 	chatUUID, err := parseChatUUIDFromCreate(createBody)
 	if err != nil {
 		log.Error("overdue ticket: parse chat uuid", zap.Error(err), zap.String("body", string(createBody)))
@@ -466,7 +510,7 @@ func OverdueTicketHandler(ctx context.Context, log *zap.Logger, event *pb.Event,
 
 	sendStatus, sendBody, err := overdueCCPost(ctx, "/cc.MessagesAPI/Send", map[string]any{
 		"chat":    chatUUID,
-		"content": formatOverdueTicketMessage(info),
+		"content": message,
 		"kind":    0,
 	}, sendToken)
 	if err != nil {

--- a/pkg/eventbus/handlers.go
+++ b/pkg/eventbus/handlers.go
@@ -394,6 +394,12 @@ func OverdueTicketHandler(ctx context.Context, log *zap.Logger, event *pb.Event,
 		event.Type = "noop"
 		return event, nil
 	}
+	if _, period := resolveOverdueDueAndPeriod(event.GetData(), info); period == 0 {
+		log.Info("overdue ticket: skipped, product has no billing period (one-time)",
+			zap.String("instance", event.GetUuid()))
+		event.Type = "noop"
+		return event, nil
+	}
 	if skipOverdueTicketUntilDelay(log, ticketConf, event.GetData(), info) {
 		event.Type = "noop"
 		return event, nil

--- a/pkg/eventbus/overdue_ticket.go
+++ b/pkg/eventbus/overdue_ticket.go
@@ -1,0 +1,263 @@
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/arangodb/go-driver"
+	"github.com/slntopp/nocloud/pkg/nocloud/schema"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	autoTicketEnabledKey     = "auto_ticket.enabled"
+	autoTicketDepartmentKey  = "auto_ticket.department"
+	autoTicketTopicKey       = "auto_ticket.topic"
+	autoTicketMessageKey     = "auto_ticket.message"
+	autoTicketSenderKey      = "auto_ticket.sender_uuid"
+	autoTicketAdminsKey      = "auto_ticket.admins"
+	autoTicketResponsibleKey = "auto_ticket.responsible"
+	autoTicketDelayHoursKey  = "auto_ticket.delay_hours"
+	autoTicketDelaysKey      = "auto_ticket.delays"
+	defaultOverdueDelayHours = int64(24)
+	overduePeriodMatchWindow = int64(2 * 24 * 3600)
+)
+
+type overdueCCDefaults struct {
+	Departments []overdueCCDepartment `json:"departments"`
+	Bot         *overdueCCBot         `json:"bot"`
+}
+
+type overdueCCDepartment struct {
+	Key          string   `json:"key"`
+	Admins       []string `json:"admins"`
+	WhmcsID      string   `json:"whmcsId"`
+	WhmcsIDSnake string   `json:"whmcs_id"`
+}
+
+type overdueCCBot struct {
+	Values map[string]string `json:"values"`
+}
+
+type overdueDelayRule struct {
+	Period int64 `json:"period"`
+	Hours  int64 `json:"hours"`
+}
+
+type overdueAutoTicketConf struct {
+	Enabled           bool
+	Department        string
+	Admins            []string
+	Responsible       string
+	Topic             string
+	Message           string
+	SenderUUID        string
+	DefaultDelayHours int64
+	Delays            []overdueDelayRule
+}
+
+type pbEventData map[string]*structpb.Value
+
+func overdueCCFetchDefaults(ctx context.Context, token string) (*overdueCCDefaults, error) {
+	status, body, err := overdueCCPost(ctx, "/cc.UsersAPI/FetchDefaults", map[string]any{
+		"fetchTemplates": false,
+	}, token)
+	if err != nil {
+		return nil, err
+	}
+	if status >= 300 {
+		return nil, fmt.Errorf("fetch defaults: status %d: %s", status, string(body))
+	}
+
+	var defaults overdueCCDefaults
+	if err := json.Unmarshal(body, &defaults); err != nil {
+		return nil, fmt.Errorf("parse defaults: %w", err)
+	}
+	return &defaults, nil
+}
+
+func parseOverdueAutoTicket(values map[string]string) overdueAutoTicketConf {
+	conf := overdueAutoTicketConf{Enabled: true, DefaultDelayHours: defaultOverdueDelayHours}
+	if len(values) == 0 {
+		return conf
+	}
+
+	switch strings.ToLower(strings.TrimSpace(values[autoTicketEnabledKey])) {
+	case "false", "0", "no":
+		conf.Enabled = false
+	}
+
+	conf.Department = strings.TrimSpace(values[autoTicketDepartmentKey])
+	conf.Topic = values[autoTicketTopicKey]
+	conf.Message = values[autoTicketMessageKey]
+	conf.SenderUUID = strings.TrimSpace(values[autoTicketSenderKey])
+	conf.Responsible = strings.TrimSpace(values[autoTicketResponsibleKey])
+
+	if raw := strings.TrimSpace(values[autoTicketDelayHoursKey]); raw != "" {
+		var hours int64
+		if _, err := fmt.Sscanf(raw, "%d", &hours); err == nil && hours >= 0 {
+			conf.DefaultDelayHours = hours
+		}
+	}
+
+	if raw := strings.TrimSpace(values[autoTicketDelaysKey]); raw != "" {
+		var rules []overdueDelayRule
+		if err := json.Unmarshal([]byte(raw), &rules); err == nil {
+			conf.Delays = rules
+		}
+	}
+
+	for _, part := range strings.Split(values[autoTicketAdminsKey], ",") {
+		if uuid := strings.TrimSpace(part); uuid != "" {
+			conf.Admins = append(conf.Admins, uuid)
+		}
+	}
+	return conf
+}
+
+func (c overdueAutoTicketConf) delaySeconds(period int64) int64 {
+	hours := c.DefaultDelayHours
+	if hours < 0 {
+		hours = defaultOverdueDelayHours
+	}
+	if period > 0 {
+		var bestHours int64
+		bestDiff := int64(-1)
+		for _, rule := range c.Delays {
+			if rule.Period <= 0 || rule.Hours < 0 {
+				continue
+			}
+			if rule.Period == period {
+				return rule.Hours * 3600
+			}
+			diff := int64(math.Abs(float64(rule.Period - period)))
+			if diff <= overduePeriodMatchWindow && (bestDiff < 0 || diff < bestDiff) {
+				bestDiff = diff
+				bestHours = rule.Hours
+			}
+		}
+		if bestDiff >= 0 {
+			return bestHours * 3600
+		}
+	}
+	return hours * 3600
+}
+
+func resolveOverdueDueAndPeriod(eventData pbEventData, info EventInfo) (due, period int64) {
+	due = int64(info.Due)
+	period = int64(info.Period)
+	if eventData != nil {
+		if v, ok := eventData["due"]; ok && v.GetNumberValue() != 0 {
+			due = int64(v.GetNumberValue())
+		}
+		if v, ok := eventData["period"]; ok && v.GetNumberValue() != 0 {
+			period = int64(v.GetNumberValue())
+		}
+	}
+	return due, period
+}
+
+func (d *overdueCCDefaults) departmentInfo(key string) (*overdueCCDepartmentInfo, error) {
+	if d == nil || key == "" {
+		return nil, fmt.Errorf("department %q not found in CC config", key)
+	}
+	for _, dep := range d.Departments {
+		if dep.Key != key {
+			continue
+		}
+		wid := strings.TrimSpace(dep.WhmcsID)
+		if wid == "" {
+			wid = strings.TrimSpace(dep.WhmcsIDSnake)
+		}
+		return &overdueCCDepartmentInfo{Admins: dep.Admins, WhmcsID: wid}, nil
+	}
+	return nil, fmt.Errorf("department %q not found in CC config", key)
+}
+
+func (d *overdueCCDefaults) autoTicketConf() overdueAutoTicketConf {
+	if d == nil || d.Bot == nil {
+		return overdueAutoTicketConf{Enabled: true, DefaultDelayHours: defaultOverdueDelayHours}
+	}
+	return parseOverdueAutoTicket(d.Bot.Values)
+}
+
+func renderOverdueTemplate(tpl string, info EventInfo) string {
+	instance := stripOverdueBillingDecor(info.Instance)
+	product := stripOverdueBillingDecor(info.Product)
+	if instance == "" {
+		instance = product
+	}
+	clientName := info.AccountTitle
+	if clientName == "" {
+		clientName = info.Account
+	}
+	return strings.NewReplacer(
+		"{CLIENT_NAME}", clientName,
+		"{INSTANCE}", instance,
+		"{PRODUCT}", product,
+		"{IPS}", formatOverdueIPs(info.Ips),
+		"{SERVICE_DETAILS}", formatOverdueServiceDetails(info),
+		"{SERVICE}", info.Service,
+	).Replace(tpl)
+}
+
+func resolveOverdueTicketTexts(conf overdueAutoTicketConf, info EventInfo) (topic, message string) {
+	topic = strings.TrimSpace(conf.Topic)
+	if topic == "" {
+		topic = formatOverdueTicketTopic(info)
+	} else {
+		topic = renderOverdueTemplate(topic, info)
+	}
+
+	message = strings.TrimSpace(conf.Message)
+	if message == "" {
+		message = formatOverdueTicketMessage(info)
+	} else {
+		message = renderOverdueTemplate(message, info)
+	}
+	return topic, message
+}
+
+const markOverdueTicketCreatedQuery = `
+LET doc = DOCUMENT(@inst)
+FILTER doc != null
+UPDATE doc WITH {
+	data: MERGE(
+		doc.data == null ? {} : doc.data,
+		{ overdue_ticket_created: true }
+	)
+} IN @@instances
+`
+
+func markOverdueTicketCreated(ctx context.Context, db driver.Database, instanceUUID string) error {
+	cursor, err := db.Query(ctx, markOverdueTicketCreatedQuery, map[string]interface{}{
+		"inst":       driver.NewDocumentID(schema.INSTANCES_COL, instanceUUID),
+		"@instances": schema.INSTANCES_COL,
+	})
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+	return nil
+}
+
+func skipOverdueTicketUntilDelay(log *zap.Logger, conf overdueAutoTicketConf, eventData pbEventData, info EventInfo) bool {
+	due, period := resolveOverdueDueAndPeriod(eventData, info)
+	if due <= 0 {
+		return false
+	}
+	delay := conf.delaySeconds(period)
+	if time.Now().Unix() >= due+delay {
+		return false
+	}
+	log.Info("overdue ticket: delay not elapsed",
+		zap.Int64("due", due),
+		zap.Int64("period", period),
+		zap.Int64("delay_seconds", delay))
+	return true
+}


### PR DESCRIPTION
## Summary
- Merge `dev` into `master`
- Resolve `pkg/eventbus/handlers.go` conflict:
  - Auto tickets Chat settings / delay / period==0 only for `overdue_ticket`
  - Keep `renew_failed_ticket` and `drive_mismatch_ticket` from master
  - `markOverdueTicketCreated` only for `overdue_ticket`
- Add `pkg/eventbus/overdue_ticket.go` from dev

## Test plan
- [x] Overdue ticket still created with Chat settings Auto tickets
- [x] `renew_failed_ticket` / `drive_mismatch_ticket` still create chats
- [x] Disabling Auto tickets does not block renew/drive tickets
- [x] One-time products (`period == 0`) skip overdue tickets only


Made with [Cursor](https://cursor.com)